### PR TITLE
fix: Properly spell `__all__`

### DIFF
--- a/src/watchpoints/__init__.py
+++ b/src/watchpoints/__init__.py
@@ -8,7 +8,7 @@ from .watch import Watch
 __version__ = "0.2.5"
 
 
-all = [
+__all__ = [
     "watch",
     "unwatch"
 ]


### PR DESCRIPTION
Fixes #38 